### PR TITLE
회원탈퇴시 외래키 제약 문제 해결

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/attendance/entity/Attendance.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/attendance/entity/Attendance.kt
@@ -9,6 +9,8 @@ import kr.flooding.backend.domain.classroom.entity.Classroom
 import kr.flooding.backend.domain.classroom.entity.HomebaseTable
 import kr.flooding.backend.domain.user.entity.User
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UuidGenerator
 import java.time.LocalDate
 import java.util.UUID
@@ -20,12 +22,15 @@ data class Attendance(
 	val id: UUID? = null,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.SET_NULL)
 	val classroom: Classroom? = null,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.SET_NULL)
 	val homebaseTable: HomebaseTable? = null,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	val student: User,
 
 	val period: Int,

--- a/src/main/kotlin/kr/flooding/backend/domain/classroom/entity/Classroom.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/classroom/entity/Classroom.kt
@@ -10,6 +10,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import kr.flooding.backend.domain.user.entity.User
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 
 @Entity
 data class Classroom(
@@ -31,5 +33,6 @@ data class Classroom(
 	val buildingType: BuildingType,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.SET_NULL)
 	val teacher: User,
 )

--- a/src/main/kotlin/kr/flooding/backend/domain/classroom/entity/HomebaseTable.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/classroom/entity/HomebaseTable.kt
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 
 @Entity
 data class HomebaseTable(
@@ -14,6 +16,7 @@ data class HomebaseTable(
 	val id: Long,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	val homebase: Classroom,
 	val tableNumber: Int,
 )

--- a/src/main/kotlin/kr/flooding/backend/domain/club/repository/ClubRepository.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/club/repository/ClubRepository.kt
@@ -20,7 +20,7 @@ interface ClubRepository : JpaRepository<Club, UUID> {
 		"""
 			SELECT c
 			FROM Club c
-			JOIN FETCH c.leader
+			LEFT JOIN FETCH c.leader
 			WHERE c.type = :type
 	""",
 	)
@@ -30,8 +30,8 @@ interface ClubRepository : JpaRepository<Club, UUID> {
 		"""
 			SELECT c
 			FROM Club c
-			JOIN FETCH c.classroom
-			JOIN FETCH c.classroom.teacher
+			LEFT JOIN FETCH c.classroom
+			LEFT JOIN FETCH c.classroom.teacher
 			WHERE c.id = :id
 	""",
 	)

--- a/src/main/kotlin/kr/flooding/backend/domain/homebase/entity/HomebaseGroup.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/homebase/entity/HomebaseGroup.kt
@@ -12,6 +12,8 @@ import kr.flooding.backend.domain.homebaseParticipants.entity.HomebaseParticipan
 import kr.flooding.backend.domain.user.entity.User
 import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UuidGenerator
 import java.time.LocalDate
 import java.util.UUID
@@ -23,11 +25,13 @@ data class HomebaseGroup(
 	val id: UUID? = null,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	val homebaseTable: HomebaseTable,
 
 	val period: Int,
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	val proposer: User,
 
 	@BatchSize(size = 100)


### PR DESCRIPTION
## 💡 개요
> 회원탈퇴시 외래키 제약이 발생하는 문제를 연관관계에 ```@OnDelete```를 추가하여 해결하고, null값 일 수 있는 테이블은 LEFT JOIN으로 수정했습니다.

#88 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
