### PR TITLE
이미지 용량 제한

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/file/controller/FileController.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/file/controller/FileController.kt
@@ -18,7 +18,7 @@ class FileController(
 	private val uploadImageUsecase: UploadImageUsecase,
 ) {
 	@PostMapping("image")
-	@Operation(summary = "이미지 업로드", description = "jpg, jpeg, jpg 확장자를 사용하는 이미지를 업로드합니다. (아직 확장자 제한 안함)")
+	@Operation(summary = "이미지 업로드")
 	fun uploadImage(
 		@RequestPart images: List<MultipartFile>,
 	): ResponseEntity<UploadImageResponse> =

--- a/src/main/kotlin/kr/flooding/backend/domain/file/usecase/UploadImageUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/file/usecase/UploadImageUsecase.kt
@@ -1,6 +1,9 @@
 package kr.flooding.backend.domain.file.usecase
 
 import kr.flooding.backend.domain.file.dto.response.UploadImageResponse
+import kr.flooding.backend.global.exception.ExceptionEnum
+import kr.flooding.backend.global.exception.HttpException
+import kr.flooding.backend.global.exception.toPair
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -23,11 +26,16 @@ class UploadImageUsecase(
 	lateinit var publicUrl: String
 
 	fun execute(images: List<MultipartFile>): UploadImageResponse {
+		val imageExtensions = listOf("png", "jpg", "jpeg")
 		val imageUrls =
 			images.map {
 				val originalName = requireNotNull(it.originalFilename)
 				val extension = originalName.split(".").last()
 				val filename = "${LocalDateTime.now()}:${randomUUID()}.$extension"
+
+				if (!imageExtensions.contains(extension)) {
+					throw HttpException(ExceptionEnum.FILE.INVALID_IMAGE_EXTENSION.toPair())
+				}
 
 				val putObjectRequest =
 					PutObjectRequest

--- a/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
@@ -107,6 +107,13 @@ sealed interface ExceptionEnum {
 		INVALID_MUSIC_URL(HttpStatus.BAD_REQUEST, "잘못된 형식의 음악 URL 입니다."),
 		NOT_FOUND_MUSIC(HttpStatus.NOT_FOUND, "존재하지 않는 음악 URL 입니다."),
 	}
+
+	enum class FILE(
+		val status: HttpStatus,
+		val reason: String,
+	) {
+		INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "jpg, png, jpeg 형식의 이미지만 업로드할 수 있습니다."),
+	}
 }
 
 fun ExceptionEnum.CLASSROOM.toPair() = Pair(this.status, this.reason)
@@ -126,3 +133,5 @@ fun ExceptionEnum.HOMEBASE.toPair() = Pair(this.status, this.reason)
 fun ExceptionEnum.ATTENDANCE.toPair() = Pair(this.status, this.reason)
 
 fun ExceptionEnum.MUSIC.toPair() = Pair(this.status, this.reason)
+
+fun ExceptionEnum.FILE.toPair() = Pair(this.status, this.reason)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,11 @@ spring:
         username: ${MAIL_USERNAME}
         password: ${MAIL_PASSWORD}
 
+    servlet:
+      multipart:
+          max-file-size: 10MB
+          max-request-size: 50MB
+
 jwt:
     access-token-key: ${ACCESS_TOKEN_KEY}
     refresh-token-key: ${REFRESH_TOKEN_KEY}


### PR DESCRIPTION
## 💡 개요

하나의 요청의 최대 용량을 50MB, 단일 이미지 최대 용량 10MB로 제한하였습니다.

#141 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
