### PR TITLE
이미지 업로드 병렬로 처리

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/file/usecase/UploadImageUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/file/usecase/UploadImageUsecase.kt
@@ -7,6 +7,7 @@ import kr.flooding.backend.global.exception.HttpException
 import kr.flooding.backend.global.exception.toPair
 import kr.flooding.backend.global.properties.AwsProperties
 import kr.flooding.backend.global.util.FileUtil
+import kr.flooding.backend.global.util.FileUtil.Companion.isImageExtension
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -15,6 +16,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.time.LocalDateTime
 import java.util.UUID.randomUUID
+import java.util.concurrent.Executors
 
 @Service
 @Transactional
@@ -23,39 +25,41 @@ class UploadImageUsecase(
 	private val fileUtil: FileUtil,
 	private val awsProperties: AwsProperties,
 ) {
-
 	fun execute(images: List<MultipartFile>): UploadImageListResponse {
-		val imageExtensions = listOf("png", "jpg", "jpeg", "gif")
-		val imageUrls =
-			images.map {
-				val originalName = requireNotNull(it.originalFilename)
-				val extension = originalName.split(".").last()
-
-				if (!imageExtensions.contains(extension)) {
-					throw HttpException(ExceptionEnum.FILE.INVALID_IMAGE_EXTENSION.toPair())
-				}
-
-				val filename = "${LocalDateTime.now()}:${randomUUID()}.webp"
-				val key = "images/$filename"
-
-				val webpImage = fileUtil.convertToWebp(filename, it)
-
-				val putObjectRequest =
-					PutObjectRequest
-						.builder()
-						.bucket(awsProperties.s3.bucketName)
-						.key(key)
-						.build()
-				val requestBody = RequestBody.fromInputStream(webpImage.inputStream(), webpImage.size.toLong())
-
-				s3Client.putObject(putObjectRequest, requestBody)
-
-				UploadImageResponse(
-					key = key,
-					presignedUrl = fileUtil.generatePresignedUrl(key)
-				)
+		images.forEach {
+			if(!it.isImageExtension()){
+				throw HttpException(ExceptionEnum.FILE.INVALID_IMAGE_EXTENSION.toPair())
 			}
+		}
 
-		return UploadImageListResponse(imageUrls)
+		Executors.newVirtualThreadPerTaskExecutor().use { executor ->
+			val futures = images.map {
+				executor.submit<UploadImageResponse> { uploadImage(it) }
+			}
+			val imageUrls = futures.map { it.get() }
+			return UploadImageListResponse(imageUrls)
+		}
+	}
+
+	fun uploadImage(image: MultipartFile): UploadImageResponse {
+		val filename = "${LocalDateTime.now()}:${randomUUID()}.webp"
+		val key = "images/$filename"
+
+		val webpImage = fileUtil.convertToWebp(filename, image)
+
+		val putObjectRequest =
+			PutObjectRequest
+				.builder()
+				.bucket(awsProperties.s3.bucketName)
+				.key(key)
+				.build()
+		val requestBody = RequestBody.fromInputStream(webpImage.inputStream(), webpImage.size.toLong())
+
+		s3Client.putObject(putObjectRequest, requestBody)
+
+		return UploadImageResponse(
+			key = key,
+			presignedUrl = fileUtil.generatePresignedUrl(key)
+		)
 	}
 }

--- a/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
@@ -117,6 +117,7 @@ sealed interface ExceptionEnum {
 	) {
 		INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "jpg, png, jpeg 형식의 이미지만 업로드할 수 있습니다."),
 		FAILED_TO_CONVERT_WEBP(HttpStatus.BAD_REQUEST, "webp 변환에 실패하였습니다."),
+		FAILED_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "이미지 전송에 실패하였습니다.")
 	}
 
 	@Suppress("ktlint:standard:class-naming")

--- a/src/main/kotlin/kr/flooding/backend/global/util/FileUtil.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/util/FileUtil.kt
@@ -21,7 +21,15 @@ import java.time.Duration
 class FileUtil(
 	private val awsProperties: AwsProperties,
 ) {
-	val signatureDuration: Duration = Duration.ofHours(1)
+	companion object {
+		private val imageExtensions = setOf("png", "jpg", "jpeg", "gif")
+		private val signatureDuration: Duration = Duration.ofHours(1)
+
+		fun MultipartFile.isImageExtension(): Boolean {
+			val extension = this.originalFilename?.split(".")?.last()
+			return extension in imageExtensions
+		}
+	}
 
 	fun generatePresignedUrl(key: String): String {
 		val credentials = AwsBasicCredentials.create(
@@ -62,7 +70,7 @@ class FileUtil(
 	): ByteArray {
 		try {
 			val image = ImmutableImage.loader().fromStream(multipartFile.inputStream)
-			return image.bytes(WebpWriter.DEFAULT)
+			return image.bytes(WebpWriter.DEFAULT.withMultiThread())
 		} catch (e: Exception) {
 			throw HttpException(ExceptionEnum.FILE.FAILED_TO_CONVERT_WEBP.toPair())
 		}


### PR DESCRIPTION
## 💡 개요

이미지 업로드 병렬로 처리

최대 11초 걸리던 이미지 업로드 API의 처리 속도를 55% 향상 시켰습니다.

#218 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
