### PR TITLE
홈베이스 예약 시 선생님이 구성원에 참여하지 못하도록 변경

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/homebase/usecase/ReserveHomebaseTableUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/homebase/usecase/ReserveHomebaseTableUsecase.kt
@@ -32,11 +32,15 @@ class ReserveHomebaseTableUsecase(
 		val participants = userJpaRepository.findByIdIn(request.participants)
 		val nowDate = LocalDate.now()
 
-		request.participants
-			.takeIf { it.contains(currentUser.id) }
-			?.let {
+		participants.forEach {
+			if (it == currentUser) {
 				throw HttpException(ExceptionEnum.CLASSROOM.PROPOSER_CANNOT_BE_PARTICIPANT.toPair())
 			}
+
+			if (it.studentInfo == null) {
+				throw HttpException(ExceptionEnum.HOMEBASE.HOMEBASE_ONLY_STUDENT_ALLOWED.toPair())
+			}
+		}
 
 		val homebaseTable =
 			homebaseTableJdslRepository

--- a/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/exception/ExceptionEnum.kt
@@ -89,6 +89,7 @@ sealed interface ExceptionEnum {
 		val reason: String,
 	) {
 		MAX_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "해당 테이블의 자리보다 신청자가 많습니다."),
+		HOMEBASE_ONLY_STUDENT_ALLOWED(HttpStatus.BAD_REQUEST, "학생만 홈베이스에 참여할 수 있습니다."),
 	}
 
 	enum class ATTENDANCE(


### PR DESCRIPTION
## 💡 개요

> 홈베이스 예약 시 학생만 구성원에 참여할 수 있도록 변경하여 선생님이 구성원에 참여하지 못하도록 변경했습니다.

#108 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
