### PR TITLE
자습, 안마의자 인원 반환 필드 네이밍 불일치

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/massage/dto/response/FetchMassageResponse.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/massage/dto/response/FetchMassageResponse.kt
@@ -1,7 +1,7 @@
 package kr.flooding.backend.domain.massage.dto.response
 
 class FetchMassageResponse (
-    val count: Int,
+    val currentCount: Int,
     val limit: Int,
     val isAvailable: Boolean,
 )

--- a/src/main/kotlin/kr/flooding/backend/domain/massage/scheduler/MassageScheduler.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/massage/scheduler/MassageScheduler.kt
@@ -12,9 +12,9 @@ class MassageScheduler(
 ) {
 	@Scheduled(cron = "0 0 0 * * *")
 	fun clearReservation() {
-		val selfStudyRoom = massageRoomJpaRepository.findAll().first()
+		val massageRoom = massageRoomJpaRepository.findAll().first()
 
 		massageReservationJpaRepository.deleteAll()
-		selfStudyRoom.clearReservationCount()
+		massageRoom.clearReservationCount()
 	}
 }

--- a/src/main/kotlin/kr/flooding/backend/domain/massage/usecase/FetchMassageUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/massage/usecase/FetchMassageUsecase.kt
@@ -37,7 +37,7 @@ class FetchMassageUsecase(
 			massageRoom.reservationCount < massageRoom.reservationLimit
 
 		return FetchMassageResponse(
-			count = massageRoom.reservationCount,
+			currentCount = massageRoom.reservationCount,
 			limit = massageRoom.reservationLimit,
 			isAvailable = isAvailable,
 		)


### PR DESCRIPTION
## 💡 개요
- 자습, 안마의자 인원 반환 필드 네이밍 currentCount 통합
- 안마의자 스케줄러 오타 수정

#261 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?