### PR TITLE
자습 금지 리스트 조회 API

### DIFF
--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/controller/SelfStudyAdminController.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/controller/SelfStudyAdminController.kt
@@ -3,6 +3,7 @@ package kr.flooding.backend.domain.selfStudy.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import kr.flooding.backend.domain.selfStudy.dto.web.request.ChangeSelfStudyLimitRequest
+import kr.flooding.backend.domain.selfStudy.dto.web.response.FetchSelfStudyBansResponse
 import kr.flooding.backend.domain.selfStudy.usecase.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -17,6 +18,7 @@ class SelfStudyAdminController(
     private val attendSelfStudyUsecase: AttendSelfStudyUsecase,
     private val absenceSelfStudyUsecase: AbsenceSelfStudyUsecase,
     private val cancelSelfStudyBanUsecase: CancelSelfStudyBanUsecase,
+    private val fetchSelfStudyBansUsecase: FetchSelfStudyBansUsecase,
 ) {
     @Operation(summary = "자습 최대 인원 변경")
     @PatchMapping("/limit")
@@ -34,6 +36,13 @@ class SelfStudyAdminController(
     ): ResponseEntity<Unit> =
         banSelfStudyUsecase.execute(selfStudyReservationId).let {
             ResponseEntity.ok().build()
+        }
+
+    @Operation(summary = "자습 금지 리스트 조회")
+    @GetMapping("/ban")
+    fun fetchSelfStudyBans(): ResponseEntity<FetchSelfStudyBansResponse> =
+        fetchSelfStudyBansUsecase.execute().let {
+            ResponseEntity.ok(it)
         }
 
     @Operation(summary = "자습 정지 취소")

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/controller/SelfStudyAdminController.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/controller/SelfStudyAdminController.kt
@@ -46,11 +46,11 @@ class SelfStudyAdminController(
         }
 
     @Operation(summary = "자습 정지 취소")
-    @DeleteMapping("/{selfStudyReservationId}/ban")
+    @DeleteMapping("/{selfStudyBanId}/ban")
     fun cancelSelfStudyBan(
-        @PathVariable selfStudyReservationId: UUID
+        @PathVariable selfStudyBanId: UUID
     ): ResponseEntity<Unit> =
-        cancelSelfStudyBanUsecase.execute(selfStudyReservationId).let {
+        cancelSelfStudyBanUsecase.execute(selfStudyBanId).let {
             ResponseEntity.ok().build()
         }
 

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/dto/common/response/FetchSelfStudyBanResponse.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/dto/common/response/FetchSelfStudyBanResponse.kt
@@ -1,0 +1,29 @@
+package kr.flooding.backend.domain.selfStudy.dto.common.response
+
+import kr.flooding.backend.domain.file.shared.PresignedUrlModel
+import kr.flooding.backend.domain.selfStudy.persistence.entity.SelfStudyBan
+import java.util.UUID
+
+data class FetchSelfStudyBanResponse(
+    val id: UUID,
+    val studentNumber: String,
+    val profileImage: PresignedUrlModel?,
+    val name: String,
+) {
+    companion object {
+        fun toDto(
+            selfStudyBan: SelfStudyBan,
+            profileImage: PresignedUrlModel?,
+        ): FetchSelfStudyBanResponse {
+            val studentInfo = requireNotNull(selfStudyBan.student.studentInfo)
+            val id = checkNotNull(selfStudyBan.id) { "SelfStudyBan ID must not be null." }
+
+            return FetchSelfStudyBanResponse(
+                id = id,
+                studentNumber = studentInfo.toSchoolNumber(),
+                profileImage = profileImage,
+                name = selfStudyBan.student.name,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/dto/web/response/FetchSelfStudyBansResponse.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/dto/web/response/FetchSelfStudyBansResponse.kt
@@ -1,0 +1,7 @@
+package kr.flooding.backend.domain.selfStudy.dto.web.response
+
+import kr.flooding.backend.domain.selfStudy.dto.common.response.FetchSelfStudyBanResponse
+
+data class FetchSelfStudyBansResponse(
+    val selfStudyBans: List<FetchSelfStudyBanResponse>
+)

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/persistence/entity/SelfStudyBan.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/persistence/entity/SelfStudyBan.kt
@@ -4,13 +4,15 @@ import jakarta.persistence.*
 import kr.flooding.backend.domain.user.persistence.entity.User
 import org.hibernate.annotations.OnDelete
 import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.UuidGenerator
 import java.time.LocalDate
+import java.util.UUID
 
 @Entity
 class SelfStudyBan(
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    @UuidGenerator
+    val id: UUID? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(unique = true)

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/persistence/repository/jpa/SelfStudyBanJpaRepository.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/persistence/repository/jpa/SelfStudyBanJpaRepository.kt
@@ -5,8 +5,9 @@ import kr.flooding.backend.domain.user.persistence.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 import java.util.Optional
+import java.util.UUID
 
-interface SelfStudyBanJpaRepository: JpaRepository<SelfStudyBan, Long> {
+interface SelfStudyBanJpaRepository: JpaRepository<SelfStudyBan, UUID> {
     fun existsByStudent(student: User): Boolean
     fun deleteAllByResumeDateBefore(currentDate: LocalDate)
     fun findByStudent(student: User): Optional<SelfStudyBan>

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/usecase/CancelSelfStudyBanUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/usecase/CancelSelfStudyBanUsecase.kt
@@ -1,6 +1,5 @@
 package kr.flooding.backend.domain.selfStudy.usecase
 
-import kr.flooding.backend.domain.selfStudy.persistence.repository.jpa.SelfStudyReservationJpaRepository
 import kr.flooding.backend.domain.selfStudy.persistence.repository.jpa.SelfStudyBanJpaRepository
 import kr.flooding.backend.global.exception.ExceptionEnum
 import kr.flooding.backend.global.exception.HttpException
@@ -12,16 +11,10 @@ import java.util.UUID
 @Service
 @Transactional
 class CancelSelfStudyBanUsecase(
-    private val selfStudyReservationJpaRepository: SelfStudyReservationJpaRepository,
     private val selfStudyBanJpaRepository: SelfStudyBanJpaRepository,
 ) {
-    fun execute(selfStudyReservationId: UUID) {
-        val selfStudyReservation =
-            selfStudyReservationJpaRepository.findById(selfStudyReservationId).orElseThrow {
-                HttpException(ExceptionEnum.SELF_STUDY.NOT_FOUND_SELF_STUDY_RESERVATION.toPair())
-            }
-
-        val selfStudyBan = selfStudyBanJpaRepository.findByStudent(selfStudyReservation.student).orElseThrow {
+    fun execute(selfStudyBanId: UUID) {
+        val selfStudyBan = selfStudyBanJpaRepository.findById(selfStudyBanId).orElseThrow {
             HttpException(ExceptionEnum.SELF_STUDY.NOT_FOUND_SELF_STUDY_BAN.toPair())
         }
 

--- a/src/main/kotlin/kr/flooding/backend/domain/selfStudy/usecase/FetchSelfStudyBansUsecase.kt
+++ b/src/main/kotlin/kr/flooding/backend/domain/selfStudy/usecase/FetchSelfStudyBansUsecase.kt
@@ -1,0 +1,30 @@
+package kr.flooding.backend.domain.selfStudy.usecase
+
+import jakarta.transaction.Transactional
+import kr.flooding.backend.domain.selfStudy.dto.common.response.FetchSelfStudyBanResponse
+import kr.flooding.backend.domain.selfStudy.dto.web.response.FetchSelfStudyBansResponse
+import kr.flooding.backend.domain.selfStudy.persistence.repository.jpa.SelfStudyBanJpaRepository
+import kr.flooding.backend.global.thirdparty.s3.adapter.S3Adapter
+import org.springframework.stereotype.Service
+
+@Service
+@Transactional
+class FetchSelfStudyBansUsecase(
+    private val selfStudyBanJpaRepository: SelfStudyBanJpaRepository,
+    private val s3Adapter: S3Adapter,
+) {
+    fun execute(): FetchSelfStudyBansResponse {
+        val selfStudyBans = selfStudyBanJpaRepository.findAll()
+
+        return FetchSelfStudyBansResponse(
+            selfStudyBans.map { selfStudyBan ->
+                FetchSelfStudyBanResponse.toDto(
+                    selfStudyBan = selfStudyBan,
+                    profileImage = selfStudyBan.student.profileImageKey?.let {
+                        s3Adapter.generatePresignedUrl(it)
+                    }
+                )
+            }
+        )
+    }
+}

--- a/src/main/kotlin/kr/flooding/backend/global/security/configuration/SecurityConfig.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/security/configuration/SecurityConfig.kt
@@ -66,7 +66,7 @@ class SecurityConfig(
 				.requestMatchers(HttpMethod.PATCH, "/admin/self-study/limit").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.GET, "/admin/self-study/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.POST, "/admin/self-study/{selfStudyReservationId}/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
-				.requestMatchers(HttpMethod.DELETE, "/admin/self-study/{selfStudyReservationId}/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
+				.requestMatchers(HttpMethod.DELETE, "/admin/self-study/{selfStudyBanId}/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.PATCH, "/admin/self-study/{selfStudyReservationId}/attend").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.PATCH, "/admin/self-study/{selfStudyReservationId}/absence").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 

--- a/src/main/kotlin/kr/flooding/backend/global/security/configuration/SecurityConfig.kt
+++ b/src/main/kotlin/kr/flooding/backend/global/security/configuration/SecurityConfig.kt
@@ -64,6 +64,7 @@ class SecurityConfig(
 
 			it // Self Study Management
 				.requestMatchers(HttpMethod.PATCH, "/admin/self-study/limit").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
+				.requestMatchers(HttpMethod.GET, "/admin/self-study/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.POST, "/admin/self-study/{selfStudyReservationId}/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.DELETE, "/admin/self-study/{selfStudyReservationId}/ban").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)
 				.requestMatchers(HttpMethod.PATCH, "/admin/self-study/{selfStudyReservationId}/attend").hasAnyAuthority(ROLE_DORMITORY_COUNCIL, ROLE_DORMITORY_TEACHER)


### PR DESCRIPTION
## 💡 개요

> 자습 정지 테이블 PK 타입 UUID로 변경
> 자습 금지 리스트 조회 API 구현
> 자습 정지 취소시 자습 정지 ID를 받도록 변경

#322 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 변경된 코드가 문서에 반영되었나요?
- [x] 정상적으로 동작하나요?
- [x] 병합하는 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?